### PR TITLE
sorted nav bars to use nunjucks to make it easier to manage and maintain

### DIFF
--- a/app/assets/sass/main.scss
+++ b/app/assets/sass/main.scss
@@ -25,3 +25,15 @@
     text-decoration: none; 
     color: 	#768692!important; 
 }
+
+.nav-active {
+    background-color: #005EB8;
+    font-weight: 600;
+    border-top: #005eb8 1px solid;
+    border-bottom: #005eb8 1px solid;
+
+}
+
+.nav-active a {
+    color: white!important;
+}

--- a/app/views/includes/me__left-nav.html
+++ b/app/views/includes/me__left-nav.html
@@ -1,0 +1,35 @@
+
+<li {% if activesub == "create" %} class="nav-active"{% endif %}>							
+    <a href="create-case">
+        Create a new case
+    </a>
+</li>
+<li {% if activesub == "cases" %} class="nav-active"{% endif %}>							
+    <a href="all-cases"> 
+        All cases
+    </a>
+</li>
+
+<li {% if activesub == "up-cases" %} class="nav-active"{% endif %} class="nav-inactive">							
+    <a href="urgent-priority-cases">
+        Urgent and priority cases
+    </a>
+</li>
+
+<li {% if activesub == "feedback-cases" %} class="nav-active"{% endif %} class="nav-inactive">								
+    <a href="cases-awaiting-feedback">
+        Cases awaiting coroner feedback
+    </a>
+</li>
+
+<li {% if activesub == "closed-cases" %} class="nav-active"{% endif %} class="nav-inactive">	
+    <a href="closed-cases">
+        Closed cases
+    </a>
+</li>
+
+<li>							
+    <a href="/">
+        Log out
+    </a>
+</li>

--- a/app/views/includes/meo__left-nav.html
+++ b/app/views/includes/meo__left-nav.html
@@ -1,0 +1,35 @@
+
+<li {% if activesub == "create" %} class="nav-active"{% endif %}>							
+    <a href="create-case">
+        Create a new case
+    </a>
+</li>
+<li {% if activesub == "cases" %} class="nav-active"{% endif %}>							
+    <a href="all-cases"> 
+        All cases
+    </a>
+</li>
+
+<li {% if activesub == "up-cases" %} class="nav-active"{% endif %} class="nav-inactive">							
+    <a href="urgent-priority-cases">
+        Urgent and priority cases
+    </a>
+</li>
+
+<li {% if activesub == "feedback-cases" %} class="nav-active"{% endif %} class="nav-inactive">								
+    <a href="cases-awaiting-feedback">
+        Cases awaiting coroner feedback
+    </a>
+</li>
+
+<li {% if activesub == "closed-cases" %} class="nav-active"{% endif %} class="nav-inactive">	
+    <a href="closed-cases">
+        Closed cases
+    </a>
+</li>
+
+<li>							
+    <a href="/">
+        Log out
+    </a>
+</li>

--- a/app/views/includes/qap__left-nav.html
+++ b/app/views/includes/qap__left-nav.html
@@ -1,0 +1,15 @@
+<li {% if activesub == "allcase" %} class="nav-active"{% endif %}>					
+    <a href="all-cases"> 
+        All cases
+    </a>
+</li>
+<li {% if activesub == "case-learning" %} class="nav-active"{% endif %}>						
+    <a href="case-learning">
+        Case learning
+    </a>
+</li>
+<li>							
+    <a href="/">
+        Log out
+    </a>
+</li>

--- a/app/views/me-journey/all-cases-2.html
+++ b/app/views/me-journey/all-cases-2.html
@@ -4,6 +4,8 @@
 
 <!-- Extends the layout from /views/layout.html -->
 {% extends 'main-template.html' %}
+{% set active = "me-user" %}
+{% set activesub = "cases" %}
 <!-- 
   In /views/layout.html you can:
     - change the header and footer 
@@ -128,40 +130,3 @@
 	</div>
 {% endblock %}
 
-{% block sideNav %}
-	<li>							
-		<a href="create-case">
-			Create a new case
-		</a>
-	</li>
-
-	<li>							
-		<a href="all-cases" class="active"> 
-			All cases
-		</a>
-	</li>
-
-	<li class="nav-inactive">							
-		<a href="urgent-priority-cases">
-			Urgent and priority cases
-		</a>
-	</li>
-
-	<li class="nav-inactive">								
-		<a href="cases-awaiting-feedback">
-			Cases awaiting coroner feedback
-		</a>
-	</li>
-
-	<li class="nav-inactive">	
-		<a href="closed-cases">
-			Closed cases
-		</a>
-	</li>
-	
-	<li>							
-		<a href="/">
-			Log out
-		</a>
-	</li>
-{% endblock %}

--- a/app/views/me-journey/all-cases-3.html
+++ b/app/views/me-journey/all-cases-3.html
@@ -4,6 +4,8 @@
 
 <!-- Extends the layout from /views/layout.html -->
 {% extends 'main-template.html' %}
+{% set active = "me-user" %}
+{% set activesub = "cases" %}
 <!-- 
   In /views/layout.html you can:
     - change the header and footer 
@@ -128,40 +130,3 @@
 	</div>
 {% endblock %}
 
-{% block sideNav %}
-	<li>							
-		<a href="create-case">
-			Create a new case
-		</a>
-	</li>
-
-	<li>							
-		<a href="all-cases" class="active"> 
-			All cases
-		</a>
-	</li>
-
-	<li class="nav-inactive">							
-		<a href="urgent-priority-cases">
-			Urgent and priority cases
-		</a>
-	</li>
-
-	<li class="nav-inactive">								
-		<a href="cases-awaiting-feedback">
-			Cases awaiting coroner feedback
-		</a>
-	</li>
-
-	<li class="nav-inactive">	
-		<a href="closed-cases">
-			Closed cases
-		</a>
-	</li>
-	
-	<li>							
-		<a href="/">
-			Log out
-		</a>
-	</li>
-{% endblock %}

--- a/app/views/me-journey/all-cases.html
+++ b/app/views/me-journey/all-cases.html
@@ -4,6 +4,8 @@
 
 <!-- Extends the layout from /views/layout.html -->
 {% extends 'main-template.html' %}
+{% set active = "me-user" %}
+{% set activesub = "cases" %}
 <!-- 
   In /views/layout.html you can:
     - change the header and footer 
@@ -128,40 +130,3 @@
 	</div>
 {% endblock %}
 
-{% block sideNav %}
-	<li>							
-		<a href="create-case">
-			Create a new case
-		</a>
-	</li>
-
-	<li>							
-		<a href="all-cases" class="active"> 
-			All cases
-		</a>
-	</li>
-
-	<li class="nav-inactive">							
-		<a href="urgent-priority-cases">
-			Urgent and priority cases
-		</a>
-	</li>
-
-	<li class="nav-inactive">								
-		<a href="cases-awaiting-feedback">
-			Cases awaiting coroner feedback
-		</a>
-	</li>
-
-	<li class="nav-inactive">	
-		<a href="closed-cases">
-			Closed cases
-		</a>
-	</li>
-	
-	<li>							
-		<a href="/">
-			Log out
-		</a>
-	</li>
-{% endblock %}

--- a/app/views/me-journey/case-overview.html
+++ b/app/views/me-journey/case-overview.html
@@ -4,6 +4,8 @@
 
 <!-- Extends the layout from /views/layout.html -->
 {% extends 'main-template.html' %}
+{% set active = "me-user" %}
+{% set activesub = "cases" %}
 <!-- 
   In /views/layout.html you can:
     - change the header and footer 
@@ -50,40 +52,3 @@
 	</div>
 {% endblock %}
 
-{% block sideNav %}
-	<li>							
-		<a href="create-case">
-			Create a new case
-		</a>
-	</li>
-
-	<li>							
-		<a href="all-cases" class="active"> 
-			All cases
-		</a>
-	</li>
-
-	<li>							
-		<a href="urgent-priority-cases">
-			Urgent and priority cases
-		</a>
-	</li>
-
-	<li>							
-		<a href="cases-awaiting-feedback">
-			Cases awaiting coroner feedback
-		</a>
-	</li>
-
-	<li>							
-		<a href="closed-cases">
-			Closed cases
-		</a>
-	</li>
-
-	<li>							
-		<a href="/">
-			Log out
-		</a>
-	</li>
-{% endblock %}

--- a/app/views/me-journey/cases-awaiting-feedback.html
+++ b/app/views/me-journey/cases-awaiting-feedback.html
@@ -4,6 +4,8 @@
 
 <!-- Extends the layout from /views/layout.html -->
 {% extends 'main-template.html' %}
+{% set active = "me-user" %}
+{% set activesub = "feedback-cases" %}
 <!-- 
   In /views/layout.html you can:
     - change the header and footer 
@@ -79,42 +81,4 @@
             </table>	
 		</div>
 	</div>
-{% endblock %}
-
-{% block sideNav %}
-	<li>							
-		<a href="create-case">
-			Create a new case
-		</a>
-	</li>
-
-	<li>							
-		<a href="all-cases"> 
-			All cases
-		</a>
-	</li>
-
-	<li>							
-		<a href="urgent-priority-cases">
-			Urgent and priority cases
-		</a>
-	</li>
-
-	<li>							
-		<a href="cases-awaiting-feedback" class="active">
-			Cases awaiting coroner feedback
-		</a>
-	</li>
-
-	<li>							
-		<a href="closed-cases">
-			Closed cases
-		</a>
-    </li>
-    
-    <li>							
-		<a href="/">
-			Log out
-		</a>
-	</li>
 {% endblock %}

--- a/app/views/me-journey/closed-cases.html
+++ b/app/views/me-journey/closed-cases.html
@@ -4,6 +4,8 @@
 
 <!-- Extends the layout from /views/layout.html -->
 {% extends 'main-template.html' %}
+{% set active = "me-user" %}
+{% set activesub = "closed-cases" %}
 <!-- 
   In /views/layout.html you can:
     - change the header and footer 
@@ -79,42 +81,4 @@
             </table>	
 		</div>
 	</div>
-{% endblock %}
-
-{% block sideNav %}
-	<li>							
-		<a href="create-case">
-			Create a new case
-		</a>
-	</li>
-
-	<li>							
-		<a href="all-cases"> 
-			All cases
-		</a>
-	</li>
-
-	<li>							
-		<a href="urgent-priority-cases">
-			Urgent and priority cases
-		</a>
-	</li>
-
-	<li>							
-		<a href="cases-awaiting-feedback">
-			Cases awaiting coroner feedback
-		</a>
-	</li>
-
-	<li>							
-		<a href="closed-cases" class="active">
-			Closed cases
-		</a>
-    </li>
-    
-    <li>							
-		<a href="/">
-			Log out
-		</a>
-	</li>
 {% endblock %}

--- a/app/views/me-journey/create-case.html
+++ b/app/views/me-journey/create-case.html
@@ -4,6 +4,8 @@
 
 <!-- Extends the layout from /views/layout.html -->
 {% extends 'main-template.html' %}
+{% set active = "me-user" %}
+{% set activesub = "create" %}
 <!-- 
   In /views/layout.html you can:
     - change the header and footer 
@@ -35,6 +37,7 @@
 
 {% block content %}
 	<div class="nhsuk-grid-row">
+		
 		<div class="nhsuk-grid-column-full">
             <h1>
                 Create a new case
@@ -310,40 +313,3 @@
 	</div>
 {% endblock %}
 
-{% block sideNav %}
-	<li>							
-		<a href="create-case" class="active">
-			Create a new case
-		</a>
-	</li>
-
-	<li>							
-		<a href="all-cases"> 
-			All cases
-		</a>
-	</li>
-
-	<li class="nav-inactive">							
-		<a href="urgent-priority-cases">
-			Urgent and priority cases
-		</a>
-	</li>
-
-	<li class="nav-inactive">								
-		<a href="cases-awaiting-feedback">
-			Cases awaiting coroner feedback
-		</a>
-	</li>
-
-	<li class="nav-inactive">	
-		<a href="closed-cases">
-			Closed cases
-		</a>
-	</li>
-	
-	<li>							
-		<a href="/">
-			Log out
-		</a>
-	</li>
-{% endblock %}

--- a/app/views/me-journey/urgent-priority-cases.html
+++ b/app/views/me-journey/urgent-priority-cases.html
@@ -4,6 +4,8 @@
 
 <!-- Extends the layout from /views/layout.html -->
 {% extends 'main-template.html' %}
+{% set active = "me-user" %}
+{% set activesub = "up-case" %}
 <!-- 
   In /views/layout.html you can:
     - change the header and footer 
@@ -148,40 +150,3 @@
 	</div>
 {% endblock %}
 
-{% block sideNav %}
-	<li>							
-		<a href="create-case">
-			Create a new case
-		</a>
-	</li>
-
-	<li>							
-		<a href="all-cases"> 
-			All cases
-		</a>
-	</li>
-
-	<li>							
-		<a href="urgent-priority-cases" class="active">
-			Urgent and priority cases
-		</a>
-	</li>
-
-	<li>							
-		<a href="cases-awaiting-feedback">
-			Cases awaiting coroner feedback
-		</a>
-	</li>
-
-	<li>							
-		<a href="closed-cases">
-			Closed cases
-		</a>
-	</li>
-
-	<li>							
-		<a href="/">
-			Log out
-		</a>
-	</li>
-{% endblock %}

--- a/app/views/meo-journey/all-cases-2.html
+++ b/app/views/meo-journey/all-cases-2.html
@@ -4,6 +4,8 @@
 
 <!-- Extends the layout from /views/layout.html -->
 {% extends 'main-template.html' %}
+{% set active = "meo-user" %}
+{% set activesub = "cases" %}
 <!-- 
   In /views/layout.html you can:
     - change the header and footer 
@@ -126,42 +128,4 @@
 			</nav>
 		</div>
 	</div>
-{% endblock %}
-
-{% block sideNav %}
-	<li>							
-		<a href="create-case">
-			Create a new case
-		</a>
-	</li>
-
-	<li>							
-		<a href="all-cases" class="active"> 
-			All cases
-		</a>
-	</li>
-
-	<li class="nav-inactive">							
-		<a href="urgent-priority-cases">
-			Urgent and priority cases
-		</a>
-	</li>
-
-	<li class="nav-inactive">								
-		<a href="cases-awaiting-feedback">
-			Cases awaiting coroner feedback
-		</a>
-	</li>
-
-	<li class="nav-inactive">	
-		<a href="closed-cases">
-			Closed cases
-		</a>
-	</li>
-	
-	<li>							
-		<a href="/">
-			Log out
-		</a>
-	</li>
 {% endblock %}

--- a/app/views/meo-journey/all-cases-3.html
+++ b/app/views/meo-journey/all-cases-3.html
@@ -4,6 +4,8 @@
 
 <!-- Extends the layout from /views/layout.html -->
 {% extends 'main-template.html' %}
+{% set active = "meo-user" %}
+{% set activesub = "cases" %}
 <!-- 
   In /views/layout.html you can:
     - change the header and footer 
@@ -126,42 +128,4 @@
 			</nav>
 		</div>
 	</div>
-{% endblock %}
-
-{% block sideNav %}
-	<li>							
-		<a href="create-case">
-			Create a new case
-		</a>
-	</li>
-
-	<li>							
-		<a href="all-cases" class="active"> 
-			All cases
-		</a>
-	</li>
-
-	<li class="nav-inactive">							
-		<a href="urgent-priority-cases">
-			Urgent and priority cases
-		</a>
-	</li>
-
-	<li class="nav-inactive">								
-		<a href="cases-awaiting-feedback">
-			Cases awaiting coroner feedback
-		</a>
-	</li>
-
-	<li class="nav-inactive">	
-		<a href="closed-cases">
-			Closed cases
-		</a>
-	</li>
-	
-	<li>							
-		<a href="/">
-			Log out
-		</a>
-	</li>
 {% endblock %}

--- a/app/views/meo-journey/all-cases.html
+++ b/app/views/meo-journey/all-cases.html
@@ -4,6 +4,8 @@
 
 <!-- Extends the layout from /views/layout.html -->
 {% extends 'main-template.html' %}
+{% set active = "meo-user" %}
+{% set activesub = "cases" %}
 <!-- 
   In /views/layout.html you can:
     - change the header and footer 
@@ -126,42 +128,4 @@
 			</nav>
 		</div>
 	</div>
-{% endblock %}
-
-{% block sideNav %}
-	<li>							
-		<a href="create-case">
-			Create a new case
-		</a>
-	</li>
-
-	<li>							
-		<a href="all-cases" class="active"> 
-			All cases
-		</a>
-	</li>
-
-	<li class="nav-inactive">							
-		<a href="urgent-priority-cases">
-			Urgent and priority cases
-		</a>
-	</li>
-
-	<li class="nav-inactive">								
-		<a href="cases-awaiting-feedback">
-			Cases awaiting coroner feedback
-		</a>
-	</li>
-
-	<li class="nav-inactive">	
-		<a href="closed-cases">
-			Closed cases
-		</a>
-	</li>
-	
-	<li>							
-		<a href="/">
-			Log out
-		</a>
-	</li>
 {% endblock %}

--- a/app/views/meo-journey/case-overview.html
+++ b/app/views/meo-journey/case-overview.html
@@ -4,6 +4,8 @@
 
 <!-- Extends the layout from /views/layout.html -->
 {% extends 'main-template.html' %}
+{% set active = "meo-user" %}
+{% set activesub = "cases" %}
 <!-- 
   In /views/layout.html you can:
     - change the header and footer 
@@ -48,42 +50,4 @@
             </p>
 		</div>
 	</div>
-{% endblock %}
-
-{% block sideNav %}
-	<li>							
-		<a href="create-case">
-			Create a new case
-		</a>
-	</li>
-
-	<li>							
-		<a href="all-cases" class="active"> 
-			All cases
-		</a>
-	</li>
-
-	<li>							
-		<a href="urgent-priority-cases">
-			Urgent and priority cases
-		</a>
-	</li>
-
-	<li>							
-		<a href="cases-awaiting-feedback">
-			Cases awaiting coroner feedback
-		</a>
-	</li>
-
-	<li>							
-		<a href="closed-cases">
-			Closed cases
-		</a>
-	</li>
-
-	<li>							
-		<a href="/">
-			Log out
-		</a>
-	</li>
 {% endblock %}

--- a/app/views/meo-journey/cases-awaiting-feedback.html
+++ b/app/views/meo-journey/cases-awaiting-feedback.html
@@ -4,6 +4,8 @@
 
 <!-- Extends the layout from /views/layout.html -->
 {% extends 'main-template.html' %}
+{% set active = "meo-user" %}
+{% set activesub = "feedback-cases" %}
 <!-- 
   In /views/layout.html you can:
     - change the header and footer 
@@ -79,42 +81,4 @@
             </table>	
 		</div>
 	</div>
-{% endblock %}
-
-{% block sideNav %}
-	<li>							
-		<a href="create-case">
-			Create a new case
-		</a>
-	</li>
-
-	<li>							
-		<a href="all-cases"> 
-			All cases
-		</a>
-	</li>
-
-	<li>							
-		<a href="urgent-priority-cases">
-			Urgent and priority cases
-		</a>
-	</li>
-
-	<li>							
-		<a href="cases-awaiting-feedback" class="active">
-			Cases awaiting coroner feedback
-		</a>
-	</li>
-
-	<li>							
-		<a href="closed-cases">
-			Closed cases
-		</a>
-    </li>
-    
-    <li>							
-		<a href="/">
-			Log out
-		</a>
-	</li>
 {% endblock %}

--- a/app/views/meo-journey/closed-cases.html
+++ b/app/views/meo-journey/closed-cases.html
@@ -4,6 +4,8 @@
 
 <!-- Extends the layout from /views/layout.html -->
 {% extends 'main-template.html' %}
+{% set active = "meo-user" %}
+{% set activesub = "closed-cases" %}
 <!-- 
   In /views/layout.html you can:
     - change the header and footer 
@@ -79,42 +81,4 @@
             </table>	
 		</div>
 	</div>
-{% endblock %}
-
-{% block sideNav %}
-	<li>							
-		<a href="create-case">
-			Create a new case
-		</a>
-	</li>
-
-	<li>							
-		<a href="all-cases"> 
-			All cases
-		</a>
-	</li>
-
-	<li>							
-		<a href="urgent-priority-cases">
-			Urgent and priority cases
-		</a>
-	</li>
-
-	<li>							
-		<a href="cases-awaiting-feedback">
-			Cases awaiting coroner feedback
-		</a>
-	</li>
-
-	<li>							
-		<a href="closed-cases" class="active">
-			Closed cases
-		</a>
-    </li>
-    
-    <li>							
-		<a href="/">
-			Log out
-		</a>
-	</li>
 {% endblock %}

--- a/app/views/meo-journey/create-case.html
+++ b/app/views/meo-journey/create-case.html
@@ -4,6 +4,8 @@
 
 <!-- Extends the layout from /views/layout.html -->
 {% extends 'main-template.html' %}
+{% set active = "meo-user" %}
+{% set activesub = "create" %}
 <!-- 
   In /views/layout.html you can:
     - change the header and footer 
@@ -308,42 +310,4 @@
 			</div>
 		</div>
 	</div>
-{% endblock %}
-
-{% block sideNav %}
-	<li>							
-		<a href="create-case" class="active">
-			Create a new case
-		</a>
-	</li>
-
-	<li>							
-		<a href="all-cases"> 
-			All cases
-		</a>
-	</li>
-
-	<li class="nav-inactive">							
-		<a href="urgent-priority-cases">
-			Urgent and priority cases
-		</a>
-	</li>
-
-	<li class="nav-inactive">								
-		<a href="cases-awaiting-feedback">
-			Cases awaiting coroner feedback
-		</a>
-	</li>
-
-	<li class="nav-inactive">	
-		<a href="closed-cases">
-			Closed cases
-		</a>
-	</li>
-	
-	<li>							
-		<a href="/">
-			Log out
-		</a>
-	</li>
 {% endblock %}

--- a/app/views/meo-journey/urgent-priority-cases.html
+++ b/app/views/meo-journey/urgent-priority-cases.html
@@ -4,6 +4,8 @@
 
 <!-- Extends the layout from /views/layout.html -->
 {% extends 'main-template.html' %}
+{% set active = "meo-user" %}
+{% set activesub = "up-case" %}
 <!-- 
   In /views/layout.html you can:
     - change the header and footer 
@@ -146,42 +148,4 @@
 			</div>
 		</div>
 	</div>
-{% endblock %}
-
-{% block sideNav %}
-	<li>							
-		<a href="create-case">
-			Create a new case
-		</a>
-	</li>
-
-	<li>							
-		<a href="all-cases"> 
-			All cases
-		</a>
-	</li>
-
-	<li>							
-		<a href="urgent-priority-cases" class="active">
-			Urgent and priority cases
-		</a>
-	</li>
-
-	<li>							
-		<a href="cases-awaiting-feedback">
-			Cases awaiting coroner feedback
-		</a>
-	</li>
-
-	<li>							
-		<a href="closed-cases">
-			Closed cases
-		</a>
-	</li>
-
-	<li>							
-		<a href="/">
-			Log out
-		</a>
-	</li>
 {% endblock %}

--- a/app/views/qap-journey/all-cases.html
+++ b/app/views/qap-journey/all-cases.html
@@ -4,6 +4,8 @@
 
 <!-- Extends the layout from /views/layout.html -->
 {% extends 'main-template.html' %}
+{% set active = "qap-user" %}
+{% set activesub = "allcase" %}
 <!-- 
   In /views/layout.html you can:
     - change the header and footer 
@@ -125,25 +127,4 @@
 			</div>
 		</div>
 	</div>
-{% endblock %}
-
-{% block sideNav %}
-
-	<li>							
-		<a href="all-cases" class="active"> 
-			All cases
-		</a>
-	</li>
-
-	<li>							
-		<a href="case-learning">
-			Case learning
-		</a>
-    </li>
-    
-    <li>							
-		<a href="/">
-			Log out
-		</a>
-	</li>
 {% endblock %}

--- a/app/views/qap-journey/case-learning.html
+++ b/app/views/qap-journey/case-learning.html
@@ -4,6 +4,8 @@
 
 <!-- Extends the layout from /views/layout.html -->
 {% extends 'main-template.html' %}
+{% set active = "qap-user" %}
+{% set activesub = "case-learning" %}
 <!-- 
   In /views/layout.html you can:
     - change the header and footer 
@@ -83,25 +85,4 @@
             </div>
 		</div>
 	</div>
-{% endblock %}
-
-{% block sideNav %}
-
-	<li>							
-		<a href="all-cases"> 
-			All cases
-		</a>
-	</li>
-
-	<li>							
-		<a href="case-learning" class="active">
-			Case learning
-		</a>
-    </li>
-    
-    <li>							
-		<a href="/">
-			Log out
-		</a>
-	</li>
 {% endblock %}

--- a/docs/views/main-template.html
+++ b/docs/views/main-template.html
@@ -150,45 +150,26 @@
                             Last log in: 08/09/2020 11:31:07
                         </p>
 
+      
                         <ul>
                             <div id="options" class="options">
                                 {% block sideNav %}
-                                <li>							
-                                    <a href="#">
-                                        Create a new case
-                                    </a>
-                                </li>
 
-                                <li>							
-                                    <a href="#" class="active"> 
-                                        All cases
-                                    </a>
-                                </li>
+                                {% if active == "me-user" %} 
+                                  {% include "includes/me__left-nav.html" %}
+                                {% elif active == "meo-user" %} 
+                                  {% include "includes/meo__left-nav.html" %}
+                                {% elif active == "qap-user" %} 
+                                  {% include "includes/qap__left-nav.html" %}
+                                {% endif %} 
 
-                                <li>							
-                                    <a href="#">
-                                        Urgent and priority cases
-                                    </a>
-                                </li>
-
-                                <li>							
-                                    <a href="#">
-                                        Cases awaiting coroner feedback
-                                    </a>
-                                </li>
-
-                                <li>							
-                                    <a href="#">
-                                        Closed cases
-                                    </a>
-                                </li>
                                 {% endblock %}
                             </div>
                         </ul>
                     </div>
                   </div>
                 </div>
-                
+                      
                 <div class="nhsabsa-sidebar-content" id="maincontent">
                     {% block content %}{% endblock %}
                 </div>
@@ -196,7 +177,7 @@
             </div>
         </div>
       {% endblock %}
-
+                
       {% block footer %}
       <footer role="contentinfo">
         <div class="nhsuk-footer" id="nhsuk-footer">


### PR DESCRIPTION
Added nunjucks into main template to pull in relevant side navs based on user type for each page, rather than duplicate the html across each page, makes it easier to maintain and change.

The user type is based on the sub set at the top of each html page: (add this to the top of each new html page for respective user type/journey)
                          {% set active = "meo-user" %}

The activesub will determine / identify each individual page and set active states of the nav bar, again found at the top of each individual html page:

                          {% set activesub = "closed-cases" %}
